### PR TITLE
fix bug: causing rild terminated

### DIFF
--- a/huaweigeneric-ril.c
+++ b/huaweigeneric-ril.c
@@ -4654,7 +4654,7 @@ static void requestRegistrationState(RIL_Token t, int data)
         asprintf(&responseStr[3], "%d", response[3]);
 
     if (data == 1)
-	responseStr[5] = (char*) "1";
+	asprintf(&responseStr[5], "%d",(char*) "1");
 
     RIL_onRequestComplete(t, RIL_E_SUCCESS, responseStr,
                           resp_size * sizeof(char *));


### PR DESCRIPTION
```
responseStr[5] = (char *) "1";
```

this line assign `responseStr[5]` a const string. But other `responseStr` get a dynamic buffer from `asprintf`. When the function end , it try to free these dynamic buffer. and `responseStr[5]` will cause the program exit silently.
